### PR TITLE
Use NuGet package for RiskOfOptions

### DIFF
--- a/DiscordRichPresence/DiscordRichPresence.csproj
+++ b/DiscordRichPresence/DiscordRichPresence.csproj
@@ -24,6 +24,7 @@
 	<PackageReference Include="MMHOOK.RoR2" Version="2024.11.4">
 		<NoWarn>NU1701</NoWarn>
 	</PackageReference>
+	<PackageReference Include="Rune580.Mods.RiskOfRain2.RiskOfOptions" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,9 +51,6 @@
     </Reference>
     <Reference Include="Rewired_CSharp">
       <HintPath>libs\Rewired_CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="RiskOfOptions">
-      <HintPath>libs\RiskOfOptions.dll</HintPath>
     </Reference>
     <Reference Include="UnityNamedPipe">
 	  <HintPath>libs\UnityNamedPipe.dll</HintPath>


### PR DESCRIPTION
Avoid redistributing a copy of RiskOfOptions.dll (2.8.2) as part of DiscordRichPresence. Otherwise can cause RiskOfOptions to fail to load when a newer version exists.

Should address https://github.com/Rune580/RiskOfOptions/issues/44 (and potentially https://github.com/Rune580/RiskOfOptions/issues/45 )

----

Additionally (nitpick, sorry), I'm not sure if any of the files in the libs folder are necessary or need to be included in the mod package, given that they either exist in the game files (e.g. `EOS.dll`, `Facepunch.Steamworks.dll`; in which case mark the packages using `<Private>false</Private>` like in [ScrollableLobbyUI](https://github.com/KingEnderBrine/-RoR2-ScrollableLobbyUI/blob/master/ScrollableLobbyUI/ScrollableLobbyUI.csproj#L20-L22)), or exist as NuGet packages (in which case use that and remove the dlls from the libs folder and the .csproj; e.g. `R2API.*.*`).